### PR TITLE
fix unreadable ansi brightWhite in light terminal theme

### DIFF
--- a/ayu-light-bordered.json
+++ b/ayu-light-bordered.json
@@ -178,7 +178,7 @@
 		"terminal.ansiBrightBlue": "#399ee6",
 		"terminal.ansiBrightMagenta": "#a37acc",
 		"terminal.ansiBrightCyan": "#4cbf99",
-		"terminal.ansiBrightWhite": "#ffffff"
+		"terminal.ansiBrightWhite": "#d1d1d1"
 	},
 	"tokenColors": [
 		{

--- a/ayu-light.json
+++ b/ayu-light.json
@@ -178,7 +178,7 @@
 		"terminal.ansiBrightBlue": "#399ee6",
 		"terminal.ansiBrightMagenta": "#a37acc",
 		"terminal.ansiBrightCyan": "#4cbf99",
-		"terminal.ansiBrightWhite": "#ffffff"
+		"terminal.ansiBrightWhite": "#d1d1d1"
 	},
 	"tokenColors": [
 		{

--- a/src/template.ts
+++ b/src/template.ts
@@ -7,7 +7,7 @@ const terminalColors = {
     black: '#000000',
     white: '#c7c7c7',
     brightBlack: '#686868',
-    brightWhite: '#ffffff'
+    brightWhite: '#d1d1d1'
   },
   dark: {
     black: ayu.dark.ui.line.hex(),


### PR DESCRIPTION
![ayu-bright-fix](https://user-images.githubusercontent.com/2117023/47715268-83f93d80-dc3f-11e8-9917-f61f6feea8d8.png)
fixes #68 