### PR TITLE
Add border to highlighted words in editor

### DIFF
--- a/ayu-dark-bordered.json
+++ b/ayu-dark-bordered.json
@@ -78,6 +78,8 @@
 		"editor.selectionHighlightBorder": "#1d2936",
 		"editor.wordHighlightBackground": "#121922",
 		"editor.wordHighlightStrongBackground": "#e6b45033",
+		"editor.wordHighlightBorder": "#d9d7cd",
+		"editor.wordHighlightStrongBorder": "#ffcb65",
 		"editor.findMatchBackground": "#e6b4500d",
 		"editor.findMatchBorder": "#e6b450",
 		"editor.findMatchHighlightBackground": "#e6b4500d",

--- a/ayu-dark.json
+++ b/ayu-dark.json
@@ -78,6 +78,8 @@
 		"editor.selectionHighlightBorder": "#1d2936",
 		"editor.wordHighlightBackground": "#121922",
 		"editor.wordHighlightStrongBackground": "#e6b45033",
+		"editor.wordHighlightBorder": "#d9d7cd",
+		"editor.wordHighlightStrongBorder": "#ffcb65",
 		"editor.findMatchBackground": "#e6b4500d",
 		"editor.findMatchBorder": "#e6b450",
 		"editor.findMatchHighlightBackground": "#e6b4500d",

--- a/ayu-light-bordered.json
+++ b/ayu-light-bordered.json
@@ -78,6 +78,8 @@
 		"editor.selectionHighlightBorder": "#dee8f1",
 		"editor.wordHighlightBackground": "#eff3f6",
 		"editor.wordHighlightStrongBackground": "#ff994033",
+		"editor.wordHighlightBorder": "#d9d7cd",
+		"editor.wordHighlightStrongBorder": "#ffcb65",
 		"editor.findMatchBackground": "#ff99400d",
 		"editor.findMatchBorder": "#ff9940",
 		"editor.findMatchHighlightBackground": "#ff99400d",

--- a/ayu-light.json
+++ b/ayu-light.json
@@ -78,6 +78,8 @@
 		"editor.selectionHighlightBorder": "#dee8f1",
 		"editor.wordHighlightBackground": "#eff3f6",
 		"editor.wordHighlightStrongBackground": "#ff994033",
+		"editor.wordHighlightBorder": "#d9d7cd",
+		"editor.wordHighlightStrongBorder": "#ffcb65",
 		"editor.findMatchBackground": "#ff99400d",
 		"editor.findMatchBorder": "#ff9940",
 		"editor.findMatchHighlightBackground": "#ff99400d",

--- a/ayu-mirage-bordered.json
+++ b/ayu-mirage-bordered.json
@@ -78,6 +78,8 @@
 		"editor.selectionHighlightBorder": "#313e52",
 		"editor.wordHighlightBackground": "#262f3e",
 		"editor.wordHighlightStrongBackground": "#ffcc6633",
+		"editor.wordHighlightBorder": "#d9d7cd",
+		"editor.wordHighlightStrongBorder": "#ffcb65",
 		"editor.findMatchBackground": "#ffcc660d",
 		"editor.findMatchBorder": "#ffcc66",
 		"editor.findMatchHighlightBackground": "#ffcc660d",

--- a/ayu-mirage.json
+++ b/ayu-mirage.json
@@ -78,6 +78,8 @@
 		"editor.selectionHighlightBorder": "#313e52",
 		"editor.wordHighlightBackground": "#262f3e",
 		"editor.wordHighlightStrongBackground": "#ffcc6633",
+		"editor.wordHighlightBorder": "#d9d7cd",
+		"editor.wordHighlightStrongBorder": "#ffcb65",
 		"editor.findMatchBackground": "#ffcc660d",
 		"editor.findMatchBorder": "#ffcc66",
 		"editor.findMatchHighlightBackground": "#ffcc660d",

--- a/src/template.ts
+++ b/src/template.ts
@@ -139,6 +139,8 @@ export default (variant: SchemeName, bordered: boolean) => {
 
       'editor.wordHighlightBackground': scheme.ui.selection.inactive.hex(),
       'editor.wordHighlightStrongBackground': scheme.common.accent.alpha(.2).hex(),
+      'editor.wordHighlightBorder': scheme.ui.selection.accent.hex(),
+      'editor.wordHighlightStrongBorder': scheme.ui.selection.accent.hex(),
 
       'editor.findMatchBackground': scheme.common.accent.alpha(.05).hex(),
       'editor.findMatchBorder': scheme.common.accent.hex(),


### PR DESCRIPTION
Highlighted words in editor have poor visibility. For example:

<img width="195" alt="image" src="https://user-images.githubusercontent.com/5298184/80079761-fefb9580-8550-11ea-846a-0e93d9af2e9f.png">

Adding a border around the highlighted word makes it much more visible:

<img width="195" alt="image" src="https://user-images.githubusercontent.com/5298184/80079813-0e7ade80-8551-11ea-9573-818edc693ec4.png">
