### PR TITLE
link archive file extensions with archive icon

### DIFF
--- a/ayu-icons.json
+++ b/ayu-icons.json
@@ -333,7 +333,7 @@
     "yarn": {
       "iconPath": "./icons/file_type_yarn@2x.png"
     },
-    "zip": {
+    "archive": {
       "iconPath": "./icons/file_type_archive@2x.png"
     }
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ayu",
   "displayName": "Ayu",
   "description": "A simple theme with bright colors and comes in three versions — dark, light and mirage for all day long comfortable work.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "publisher": "teabyii",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
It seems like typo in icons configuration since no file extensions use "zip" icon, but "archive" icon in use by 7z, bz2, bzip2 and so on