### PR TITLE
Add colours for the comments widget

### DIFF
--- a/ayu-dark-bordered.json
+++ b/ayu-dark-bordered.json
@@ -164,6 +164,8 @@
 		"peekViewResult.lineForeground": "#565b66",
 		"peekViewResult.matchHighlightBackground": "#6c598066",
 		"peekViewResult.selectionBackground": "#47526640",
+		"editorCommentsWidget.resolvedBorder": "#565b66",
+		"editorCommentsWidget.unresolvedBorder": "#e6b450",
 		"panel.background": "#0b0e14",
 		"panel.border": "#11151c",
 		"panelTitle.activeBorder": "#e6b450",

--- a/ayu-dark.json
+++ b/ayu-dark.json
@@ -163,6 +163,8 @@
 		"peekViewResult.lineForeground": "#565b66",
 		"peekViewResult.matchHighlightBackground": "#6c598066",
 		"peekViewResult.selectionBackground": "#47526640",
+		"editorCommentsWidget.resolvedBorder": "#565b66",
+		"editorCommentsWidget.unresolvedBorder": "#e6b450",
 		"panel.background": "#0b0e14",
 		"panel.border": "#11151c",
 		"panelTitle.activeBorder": "#e6b450",

--- a/ayu-light-bordered.json
+++ b/ayu-light-bordered.json
@@ -164,6 +164,8 @@
 		"peekViewResult.lineForeground": "#8a9199",
 		"peekViewResult.matchHighlightBackground": "#9f40ffcc",
 		"peekViewResult.selectionBackground": "#56728f1f",
+		"editorCommentsWidget.resolvedBorder": "#8a9199",
+		"editorCommentsWidget.unresolvedBorder": "#ffaa33",
 		"panel.background": "#f8f9fa",
 		"panel.border": "#6b7d8f1f",
 		"panelTitle.activeBorder": "#ffaa33",

--- a/ayu-light.json
+++ b/ayu-light.json
@@ -163,6 +163,8 @@
 		"peekViewResult.lineForeground": "#8a9199",
 		"peekViewResult.matchHighlightBackground": "#9f40ffcc",
 		"peekViewResult.selectionBackground": "#56728f1f",
+		"editorCommentsWidget.resolvedBorder": "#8a9199",
+		"editorCommentsWidget.unresolvedBorder": "#ffaa33",
 		"panel.background": "#f8f9fa",
 		"panel.border": "#6b7d8f1f",
 		"panelTitle.activeBorder": "#ffaa33",

--- a/ayu-mirage-bordered.json
+++ b/ayu-mirage-bordered.json
@@ -164,6 +164,8 @@
 		"peekViewResult.lineForeground": "#707a8c",
 		"peekViewResult.matchHighlightBackground": "#69538066",
 		"peekViewResult.selectionBackground": "#63759926",
+		"editorCommentsWidget.resolvedBorder": "#707a8c",
+		"editorCommentsWidget.unresolvedBorder": "#ffcc66",
 		"panel.background": "#1f2430",
 		"panel.border": "#171b24",
 		"panelTitle.activeBorder": "#ffcc66",

--- a/ayu-mirage.json
+++ b/ayu-mirage.json
@@ -163,6 +163,8 @@
 		"peekViewResult.lineForeground": "#707a8c",
 		"peekViewResult.matchHighlightBackground": "#69538066",
 		"peekViewResult.selectionBackground": "#63759926",
+		"editorCommentsWidget.resolvedBorder": "#707a8c",
+		"editorCommentsWidget.unresolvedBorder": "#ffcc66",
 		"panel.background": "#1f2430",
 		"panel.border": "#171b24",
 		"panelTitle.activeBorder": "#ffcc66",


### PR DESCRIPTION
A recent update to VS Code added colours for comments in the UI which have resolved and unresolved states. They then use the border colour for the comments icon.

Since AYU has really subtle borders, this can result in an icon that is not very clear.

**See the icon in the comments panel at the bottom.**  
This also affects any extensions which use this colour for other related buttons.

![image](https://user-images.githubusercontent.com/150152/233422908-436e8126-6506-44f4-8d1e-701e26a2cf02.png)

This PR sets the comment border colours, which will also set these icons too.

After:  
![image](https://user-images.githubusercontent.com/150152/233422947-87ce4a4e-1fae-419d-a713-e808919109bb.png)



# Dark:

Before:  
![image](https://user-images.githubusercontent.com/150152/233423237-a0a0b207-cf62-4d10-a752-eadd1eb374b1.png)

After:  
![image](https://user-images.githubusercontent.com/150152/233423102-84855b1b-0825-4f4f-a26f-73b41d61e342.png)


# Mirage:

Before:  
![image](https://user-images.githubusercontent.com/150152/233423410-62530822-6421-45a3-977d-0426de4a94d5.png)

After:  
![image](https://user-images.githubusercontent.com/150152/233423540-dd0dafa5-5de6-4d92-b44b-5f6c49741964.png)



